### PR TITLE
Fix file name in evaluate_file_exist function

### DIFF
--- a/tasks/3-99/subtasks/0.json
+++ b/tasks/3-99/subtasks/0.json
@@ -14,7 +14,7 @@
         {
             "function": "evaluate_file_exist",
             "args": {
-                "file": "data/revenuse.docx"
+                "file": "data/revenues.docx"
           }
         }
     ]


### PR DESCRIPTION
Typo in the file name output is compared to - will always fail without updating spelling.