### PR TITLE
Fix typo in task and evaluation file names

### DIFF
--- a/tasks/3-16/subtasks/0.json
+++ b/tasks/3-16/subtasks/0.json
@@ -3,7 +3,7 @@
     "date": "2020-05-01",
     "weekday": "Friday",
     "time": "10:00 AM",
-    "task": "scan concert post file, save as notification image named notification.jpg, convert image into a concert_activaty.docx file",
+    "task": "scan concert post file, save as notification image named notification.jpg, convert image into a concert_activity.docx file",
     "evaluation": [
         {
             "function": "evaluate_file_exist",
@@ -14,7 +14,7 @@
         {
             "function": "evaluate_file_exist",
             "args": {
-                "file": "data/concert_activaty.docx"
+                "file": "data/concert_activity.docx"
             }
         }
     ]


### PR DESCRIPTION
Corrected typo including in prompt as LLMs will typically correct spelling errors